### PR TITLE
query cleanup

### DIFF
--- a/force-app/main/default/classes/UniversalDashboardController.cls
+++ b/force-app/main/default/classes/UniversalDashboardController.cls
@@ -5,27 +5,26 @@ public with sharing class UniversalDashboardController {
             return [SELECT Id, Name, Amount FROM Opportunity WHERE Amount > 1000000];
         }
 
-
         @AuraEnabled(cacheable=true)
-    public static List<Opportunity> getOpportunitiesWithCloseDateBeforeToday() {
-        return [SELECT Id, Name, CloseDate FROM Opportunity WHERE CloseDate < TODAY];
-    }
-
+        public static List<Opportunity> getOpportunitiesWithCloseDateBeforeToday() {
+            return [SELECT Id, Name, CloseDate FROM Opportunity WHERE CloseDate < TODAY];
+        }
         
-
-            //Query all the opportunity closing this week 
-            
-
+        //Query all the opportunity closing this week  
+        @AuraEnabled(cacheable=true)
+        public static List<Opportunity> getOppsClosingThisWeek() {
             List<Opportunity> oppClosingThisWeek = [SELECT Id ,
                                                             Name,
                                                             Amount,
                                                             CloseDate
                                                     FROM Opportunity 
                                                     WHERE CloseDate = THIS_WEEK];
+            return oppClosingThisWeek;
+        }
 
-
-            //Query all the opportynity whoes closing this week but still in Prospect or earlier stage 
-
+        //Query all the opportynity whoes closing this week but still in Prospect or earlier stage 
+        @AuraEnabled(cacheable=true)
+        public static List<Opportunity> getOppsClosingThisWeekInProspecting() {
             List<Opportunity> oppClosingThisWeek = [SELECT Id ,
                                                             Name,
                                                             Amount,
@@ -33,13 +32,7 @@ public with sharing class UniversalDashboardController {
                                                     FROM Opportunity 
                                                     WHERE CloseDate = THIS_WEEK                                                  
                                                     AND StageName != 'Closed Won' OR Stage != 'Close Lost' ];
-
-
-            
-        
-
-       
-
-
+            return oppClosingThisWeek;
+        }
     }
 }


### PR DESCRIPTION
cleanup on query / merge